### PR TITLE
Fixup the imports

### DIFF
--- a/release_helper/main.py
+++ b/release_helper/main.py
@@ -1,10 +1,10 @@
 import logging
 from typing import TYPE_CHECKING
 
-from .exceptions import ReleaseHelperError
-from .github import SourceControlGithub
-from .linear import IssueManagementLinear
-from .slack import MessagingSlack
+from release_helper.exceptions import ReleaseHelperError
+from release_helper.github import SourceControlGithub
+from release_helper.linear import IssueManagementLinear
+from release_helper.slack import MessagingSlack
 
 
 if TYPE_CHECKING:


### PR DESCRIPTION
Relative imports were not working as expected - likely due to the lack of base module definition. Safter path is absolute imports.